### PR TITLE
Fix Launch4j's classpath if "dontWrapJar" is "true", add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ The following example shows how to use this plugin hand in hand with the fatJar 
 
 ```
 fatJar {
-   classifier 'fat'
+    classifier 'fat'
     manifest {
-        attributes 'Main-Class': project.mainClassName
+        attributes 'Main-Class': project.mainClassName
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ An example configuration within your build.gradle for use in all Gradle versions
       mavenCentral()
     }
 
+    apply plugin: 'java'
     apply plugin: 'edu.sc.seis.launch4j'
 
     launch4j {
@@ -51,6 +52,8 @@ An example configuration within your build.gradle for use in all Gradle versions
     }
 
 The same script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
+
+    apply plugin: 'java'
 
     plugins {
       id 'edu.sc.seis.launch4j' version '1.4.1'

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ An example configuration within your build.gradle for use in all Gradle versions
     buildscript {
       repositories {
         maven {
-          url "https://plugins.gradle.org/m2/"
+          url 'https://plugins.gradle.org/m2/'
         }
       }
       dependencies {
-        classpath "gradle.plugin.edu.sc.seis.gradle:launch4j:1.4.1"
+        classpath 'gradle.plugin.edu.sc.seis.gradle:launch4j:1.4.1'
       }
     }
 
@@ -43,21 +43,21 @@ An example configuration within your build.gradle for use in all Gradle versions
       mavenCentral()
     }
 
-    apply plugin: "edu.sc.seis.launch4j"
+    apply plugin: 'edu.sc.seis.launch4j'
 
     launch4j {
-      mainClassName = "com.example.myapp.Start"
+      mainClassName = 'com.example.myapp.Start'
       icon = 'icons/myApp.ico'
     }
 
 The same script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
 
     plugins {
-      id "edu.sc.seis.launch4j" version "1.4.1"
+      id 'edu.sc.seis.launch4j' version '1.4.1'
     }
 
     launch4j {
-      mainClassName = "com.example.myapp.Start"
+      mainClassName = 'com.example.myapp.Start'
       icon = 'icons/myApp.ico'
     }
 

--- a/src/main/groovy/edu/sc/seis/launch4j/CreateLaunch4jXMLTask.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/CreateLaunch4jXMLTask.groovy
@@ -44,11 +44,9 @@ class CreateLaunch4jXMLTask extends DefaultTask {
             restartOnCrash(configuration.restartOnCrash)
             manifest(configuration.manifest)
             icon(configuration.icon)
-            if (!configuration.dontWrapJar) {
-                classPath() {
-                    mainClass(configuration.mainClassName)
-                    classpath.each() { val -> cp(val) }
-                }
+            classPath() {
+                mainClass(configuration.mainClassName)
+                classpath.each() { val -> cp(val) }
             }
             jre() {
                 xml.path(configuration.bundledJrePath != null ? configuration.bundledJrePath : "")

--- a/src/test/groovy/edu/sc/seis/launch4j/Launch4jPluginExtensionTest.groovy
+++ b/src/test/groovy/edu/sc/seis/launch4j/Launch4jPluginExtensionTest.groovy
@@ -57,4 +57,212 @@ class Launch4jPluginExtensionTest extends Specification {
         result.task(':printProperties').outcome == SUCCESS
         result.standardOutput.trim().equals('launch4j')
     }
+
+    def 'Running the task to create the executable succeeds'() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+
+            apply plugin: 'java'
+            apply plugin: 'edu.sc.seis.launch4j'
+
+            launch4j {
+                mainClassName = 'com.test.app.Main'
+            }
+        """
+
+        File sourceFile = new File(testProjectDir.newFolder('src', 'main', 'java'), 'Main.java')
+        sourceFile << """
+            package com.test.app;
+
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("Hello World!");
+                }
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('-q', 'jar', 'launch4j')
+                .build()
+
+        then:
+        result.task(':jar').outcome == SUCCESS
+        result.task(':launch4j').outcome == SUCCESS
+    }
+
+    def 'Running the created executable succeeds'() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+
+            apply plugin: 'java'
+            apply plugin: 'edu.sc.seis.launch4j'
+
+            launch4j {
+                mainClassName = 'com.test.app.Main'
+                outfile = 'test.exe'
+            }
+        """
+
+        File sourceFile = new File(testProjectDir.newFolder('src', 'main', 'java'), 'Main.java')
+        sourceFile << """
+            package com.test.app;
+
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("Hello World!");
+                }
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('-q', 'jar', 'launch4j')
+                .build()
+
+        then:
+        result.task(':jar').outcome == SUCCESS
+        result.task(':launch4j').outcome == SUCCESS
+
+        def outfile = new File(testProjectDir.root, 'build/launch4j/test.exe')
+        outfile.exists()
+
+        def process = outfile.path.execute()
+        process.waitFor() == 0
+        process.in.text.trim().equals('Hello World!')
+    }
+
+    def 'Running the created executable with Java dependencies succeeds'() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+
+            apply plugin: 'java'
+            apply plugin: 'edu.sc.seis.launch4j'
+
+            dependencies {
+                compile 'org.slf4j:slf4j-api:1.7.12'
+                runtime 'org.slf4j:slf4j-simple:1.7.12'
+            }
+
+            launch4j {
+                mainClassName = 'com.test.app.Main'
+                outfile = 'test.exe'
+            }
+        """
+
+        File sourceFile = new File(testProjectDir.newFolder('src', 'main', 'java'), 'Main.java')
+        sourceFile << """
+            package com.test.app;
+
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            public class Main {
+                private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+                public static void main(String[] args) {
+                    System.out.println("Hello STDOUT!");
+                    LOG.info("Hello LOG!");
+                }
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('-q', 'jar', 'launch4j')
+                .build()
+
+        then:
+        result.task(':jar').outcome == SUCCESS
+        result.task(':launch4j').outcome == SUCCESS
+
+        def outfile = new File(testProjectDir.root, 'build/launch4j/test.exe')
+        outfile.exists()
+
+        def process = outfile.path.execute()
+        process.waitFor() == 0
+        process.in.text.trim().equals('Hello STDOUT!')
+        process.err.text.trim().endsWith('Hello LOG!')
+    }
+
+    def 'Running an unwrapped executable with Java dependencies succeeds'() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+
+            apply plugin: 'java'
+            apply plugin: 'edu.sc.seis.launch4j'
+
+            dependencies {
+                compile 'org.slf4j:slf4j-api:1.7.12'
+                runtime 'org.slf4j:slf4j-simple:1.7.12'
+            }
+
+            ext {
+                mainTestClassName = 'com.test.app.Main'
+            }
+
+            jar {
+                manifest {
+                    attributes 'Main-Class': mainTestClassName
+                }
+            }
+
+            launch4j {
+                mainClassName = mainTestClassName
+                outfile = 'test.exe'
+                dontWrapJar = true
+            }
+        """
+
+        File sourceFile = new File(testProjectDir.newFolder('src', 'main', 'java'), 'Main.java')
+        sourceFile << """
+            package com.test.app;
+
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            public class Main {
+                private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+                public static void main(String[] args) {
+                    System.out.println("Hello STDOUT!");
+                    LOG.info("Hello LOG!");
+                }
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('-q', 'jar', 'launch4j')
+                .build()
+
+        then:
+        result.task(':jar').outcome == SUCCESS
+        result.task(':copyL4jLib').outcome == SUCCESS
+        result.task(':launch4j').outcome == SUCCESS
+
+        def outfile = new File(testProjectDir.root, 'build/launch4j/test.exe')
+        outfile.exists()
+
+        def process = outfile.path.execute()
+        process.waitFor() == 0
+        process.in.text.trim().equals('Hello STDOUT!')
+        process.err.text.trim().endsWith('Hello LOG!')
+    }
 }


### PR DESCRIPTION
According to [1] the Java plugin's default output directory is "libs", not
"lib". Fix this by generalizing the way we get the output directory.

[1] https://docs.gradle.org/current/userguide/java_plugin.html#N1245A