### PR TITLE
Creating EXE out of executable JAR - use `java -jar <name>`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,8 @@ group "edu.sc.seis.gradle"
 // use semantic versioning (http://semver.org/)
 version "1.5.1"
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource

--- a/src/main/groovy/edu/sc/seis/launch4j/CreateLaunch4jXMLTask.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/CreateLaunch4jXMLTask.groovy
@@ -44,9 +44,11 @@ class CreateLaunch4jXMLTask extends DefaultTask {
             restartOnCrash(configuration.restartOnCrash)
             manifest(configuration.manifest)
             icon(configuration.icon)
-            classPath() {
-                mainClass(configuration.mainClassName)
-                classpath.each() { val -> cp(val) }
+            if(configuration.mainClassName != null) {
+                classPath() {
+                    mainClass(configuration.mainClassName)
+                    classpath.each() { val -> cp(val) }
+                    }
             }
             jre() {
                 xml.path(configuration.bundledJrePath != null ? configuration.bundledJrePath : "")

--- a/src/main/groovy/edu/sc/seis/launch4j/Launch4jPluginExtension.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Launch4jPluginExtension.groovy
@@ -17,7 +17,7 @@ class Launch4jPluginExtension implements Serializable {
     String mainClassName
     boolean dontWrapJar = false
     String headerType = "gui"
-    private String jar
+    String jar
     String outfile
     String errTitle = ""
     String cmdLine = ""

--- a/src/test/groovy/edu/sc/seis/launch4j/Launch4jPluginExtensionTest.groovy
+++ b/src/test/groovy/edu/sc/seis/launch4j/Launch4jPluginExtensionTest.groovy
@@ -121,9 +121,11 @@ class Launch4jPluginExtensionTest extends Specification {
         def outfile = new File(testProjectDir.root, 'build/launch4j/test.exe')
         outfile.exists()
 
-        def process = outfile.path.execute()
-        process.waitFor() == 0
-        process.in.text.trim().equals('Hello World!')
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+          def process = outfile.path.execute()
+          process.waitFor() == 0
+          process.in.text.trim().equals('Hello World!')
+        }
     }
 
     def 'Running the created executable with Java dependencies succeeds'() {
@@ -176,10 +178,12 @@ class Launch4jPluginExtensionTest extends Specification {
         def outfile = new File(testProjectDir.root, 'build/launch4j/test.exe')
         outfile.exists()
 
-        def process = outfile.path.execute()
-        process.waitFor() == 0
-        process.in.text.trim().equals('Hello STDOUT!')
-        process.err.text.trim().endsWith('Hello LOG!')
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+          def process = outfile.path.execute()
+          process.waitFor() == 0
+          process.in.text.trim().equals('Hello STDOUT!')
+          process.err.text.trim().endsWith('Hello LOG!')
+        }
     }
 
     def 'Running an unwrapped executable with Java dependencies succeeds'() {
@@ -244,9 +248,11 @@ class Launch4jPluginExtensionTest extends Specification {
         def outfile = new File(testProjectDir.root, 'build/launch4j/test.exe')
         outfile.exists()
 
-        def process = outfile.path.execute()
-        process.waitFor() == 0
-        process.in.text.trim().equals('Hello STDOUT!')
-        process.err.text.trim().endsWith('Hello LOG!')
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+          def process = outfile.path.execute()
+          process.waitFor() == 0
+          process.in.text.trim().equals('Hello STDOUT!')
+          process.err.text.trim().endsWith('Hello LOG!')
+        }
     }
 }


### PR DESCRIPTION
Thanks for this wonderful plugin.

I had a specific requirement for a project. I am using the distribution plugin to create a distribution. The main folder consists of all jar files that are part of this project and the support folder contains all 3rd party JARs. One of our JARs is an executable JAR.

And also our product is compatible with Java 1.6 (and should keep like this for next one year). I used gradle-launch4j plugin to good effect with some small modifications.

1. Changed source compatibility to 1.6. I did not observe any test failures. If it is possible please keep it since both gradle and launch4j support 1.6 still.
2. Added guards to tests to ensure that they do not fail when run on non-windows platforms.
3. When mainClassName is given do not generate the `<classpath>` element. Required by launch4j to create a binary to run executable JAR.
4. Since I do not want `lib` to be prefixed to the JAR file, I made the variable public.
