### PR TITLE
Don't change the working directory by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The values configurable within the launch4j extension along with their defaults 
  *    String outfile = project.name+'.exe'
  *    String errTitle = ""
  *    String cmdLine = ""
- *    String chdir = '.'
+ *    String chdir = ""
  *    String priority = 'normal'
  *    String downloadUrl = "http://java.com/download"
  *    String supportUrl = ""

--- a/src/main/groovy/edu/sc/seis/launch4j/Launch4jPluginExtension.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Launch4jPluginExtension.groovy
@@ -22,7 +22,7 @@ class Launch4jPluginExtension implements Serializable {
     String outfile
     String errTitle = ""
     String cmdLine = ""
-    String chdir = '.'
+    String chdir = ""
     String priority = 'normal'
     String downloadUrl = "http://java.com/download"
     String supportUrl = ""


### PR DESCRIPTION
Currently, the executable changes directories to the directory containing the executable. Launch4J doesn't do this by default, and it can be confusing to have it happen automatically.