### PR TITLE
Slight correction to English grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are 8 tasks:
   * createExe - Backward compatible task to generate an .exe file.
   * **launch4j** - Placeholder task that depends on the above. *Execute this task to generate an executable.*
 
-Launch4j must not be installed separately anymore, but can be used from the *PATH* with the configuration parameter `externalLaunch4j = true`.
+Launch4j no longer needs to be installed separately, but if you want, you can still use it from the *PATH* with the configuration parameter `externalLaunch4j = true`.
 
 Configuration
 -------------


### PR DESCRIPTION
"Must not be installed separately" means you cannot install it
separately; but it seems that the author meant to indicate merely that
installing it separately is no longer NECESSARY.