### PR TITLE
Fix table rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ The values configurable within the launch4j extension along with their defaults 
 | String libraryDir | "lib" | |
 | Object copyConfigurable | | |
 | Set<String> classpath| [] | Use this property to override the classpath or configure it on you own if the `copyConfigurable` does not provide the results you want |
-|||
 | String xmlFileName | "launch4j.xml" | |
 | String mainClassName | | |
 | boolean dontWrapJar | false | |


### PR DESCRIPTION
Change README.md to remove a malformed (empty) row, which caused the
table (of the configurations) to not render correctly.