### PR TITLE
Add new jarTask property

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The values configurable within the launch4j extension along with their defaults 
 | String mainClassName | | |
 | boolean dontWrapJar | false | |
 | String headerType | "gui" | |
-| String jar | "lib/"+project.tasks[jar].archiveName or<br> "", if the JavaPlugin is not loaded | |
+| ~~String jar~~ | "lib/"+project.tasks[jar].archiveName or<br> "", if the JavaPlugin is not loaded | deprecated use `jarTask` instead |
+| Task jarTask | tasks[jar], if the JavaPlugin is loaded | Task, producing jar |
 | String outfile | project.name+'.exe' | |
 | String errTitle | "" | |
 | String cmdLine | "" | |
@@ -151,7 +152,7 @@ The following example shows how to use this plugin hand in hand with the shadow 
         outfile = 'TestMain.exe'
         mainClassName = project.mainClassName
         copyConfigurable = []
-        jar = "lib/${project.tasks.shadowJar.archiveName}"
+        jarTask = project.tasks.shadowJar
     }
 
 If you use the outdated fatJar plugin the following configuration correctly wires the execution graph:
@@ -170,7 +171,7 @@ If you use the outdated fatJar plugin the following configuration correctly wire
         outfile = 'TestMain.exe'
         mainClassName = project.mainClassName
         copyConfigurable = []
-        jar = "lib/${project.tasks.fatJar.archiveName}"
+        jarTask = project.tasks.fatJar
     }
 
 # Launch4jLibraryTask

--- a/src/backwardsCompatibiltyTest/groovy/edu/sc/seis/launch4j/Issue47Gradle4Test.groovy
+++ b/src/backwardsCompatibiltyTest/groovy/edu/sc/seis/launch4j/Issue47Gradle4Test.groovy
@@ -41,7 +41,6 @@ class Issue47Gradle4Test extends FunctionalSpecification {
                 mainTestClassName = 'com.test.app.Main'
             }
 
-            
             jar {
                 manifest {
                     attributes 'Main-Class': mainTestClassName
@@ -55,14 +54,14 @@ class Issue47Gradle4Test extends FunctionalSpecification {
                     attributes 'Main-Class': mainTestClassName
                 }
             }
-            
+
             fatJarPrepareFiles.dependsOn jar
-            
+
             launch4j {
                 outfile = 'test.exe'
                 mainClassName = mainTestClassName
                 copyConfigurable = project.tasks.fatJar.outputs.files
-                jar = "lib/" + project.tasks.fatJar.archiveName
+                jarTask = project.tasks.fatJar
             }
         """
 
@@ -78,7 +77,7 @@ class Issue47Gradle4Test extends FunctionalSpecification {
         """
 
         when:
-        def result =  createAndConfigureGradleRunner('createExe').withGradleVersion('4.10.2').build()
+        def result = createAndConfigureGradleRunner('createExe').withGradleVersion('4.10.2').build()
 
         then:
         result.task(':jar') // the task is added as fatJar dependency

--- a/src/main/groovy/edu/sc/seis/launch4j/CopyLibraries.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/CopyLibraries.groovy
@@ -19,11 +19,11 @@ package edu.sc.seis.launch4j
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.internal.file.FileOperations
-import org.gradle.api.plugins.JavaPlugin
 
 class CopyLibraries {
     Project project
@@ -38,7 +38,7 @@ class CopyLibraries {
      * Copies the project dependency jars to the configured library directory
      * @param libraryDir
      */
-    FileCollection execute(File libraryDir, Object copyConfigurable) {
+    FileCollection execute(File libraryDir, Object copyConfigurable, File jarPath) {
         def files = []
         def distSpec = {
             if (copyConfigurable != null) {
@@ -49,11 +49,17 @@ class CopyLibraries {
                         from { copyConfigurable }
                     }
                 }
-            } else if (project.plugins.hasPlugin('java')) {
-                with {
-                    from(project.tasks[JavaPlugin.JAR_TASK_NAME])
-                    from(project.configurations.findByName('runtimeClasspath') ?
-                        project.configurations.runtimeClasspath : project.configurations.runtime)
+            } else {
+                if (jarPath) {
+                    with {
+                        from { jarPath }
+                    }
+                }
+                if (project.plugins.hasPlugin('java')) {
+                    with {
+                        from(project.configurations.findByName('runtimeClasspath') ?
+                            project.configurations.runtimeClasspath : project.configurations.runtime)
+                    }
                 }
             }
             into { libraryDir }

--- a/src/main/groovy/edu/sc/seis/launch4j/CreateXML.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/CreateXML.groovy
@@ -53,7 +53,14 @@ class CreateXML {
                 // relativize paths relative to outfile
             }
         }
-        def jar = config.dontWrapJar ? outFilePath.relativize(outputDir.toPath().resolve(Paths.get(config.jar))) : config.jar
+        def jarTaskOutput = config.jarTask?.outputs?.files?.singleFile
+        def jar
+        if (config.dontWrapJar) {
+            def jarPath = jarTaskOutput ? Paths.get(config.libraryDir, jarTaskOutput.name) : Paths.get(config.jar)
+            jar = outFilePath.relativize(outputDir.toPath().resolve(jarPath))
+        } else {
+            jar = jarTaskOutput?.path ?: config.jar
+        }
         def writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(xmlFile), "UTF-8"));
         def xml = new MarkupBuilder(writer)
         xml.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8")

--- a/src/main/groovy/edu/sc/seis/launch4j/Launch4jConfiguration.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Launch4jConfiguration.groovy
@@ -18,6 +18,8 @@
 package edu.sc.seis.launch4j
 
 import groovy.transform.CompileStatic
+import org.gradle.api.Task
+import org.gradle.api.model.ReplacedBy
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 
@@ -40,7 +42,11 @@ interface Launch4jConfiguration {
 
     String getMainClassName()
 
+    @Deprecated
+    @ReplacedBy("getJarTask")
     String getJar()
+
+    Task getJarTask()
 
     Boolean getDontWrapJar()
 

--- a/src/main/groovy/edu/sc/seis/launch4j/Launch4jPluginExtension.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Launch4jPluginExtension.groovy
@@ -21,6 +21,7 @@ import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Input
@@ -39,7 +40,9 @@ class Launch4jPluginExtension implements Launch4jConfiguration {
     }
 
     String mainClassName
+    @Deprecated
     String jar
+    Task jarTask
 
     @Input
     String outputDir = 'launch4j'
@@ -149,6 +152,7 @@ class Launch4jPluginExtension implements Launch4jConfiguration {
         project.file("${getOutputDirectory()}/${xmlFileName}")
     }
 
+    @Deprecated
     String internalJar() {
         if (!jar) {
             if (project.plugins.hasPlugin('java')) {
@@ -159,6 +163,13 @@ class Launch4jPluginExtension implements Launch4jConfiguration {
             }
         }
         jar
+    }
+
+    Task internalJarTask() {
+        if (!jarTask && project.plugins.hasPlugin('java')) {
+            jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
+        }
+        jarTask
     }
 
     Set<String> classpath = []

--- a/src/test/groovy/edu/sc/seis/launch4j/Issue47Test.groovy
+++ b/src/test/groovy/edu/sc/seis/launch4j/Issue47Test.groovy
@@ -25,7 +25,6 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
  */
 class Issue47Test extends FunctionalSpecification {
 
-
     def 'Check that the shadowJar task is not present on a normal build succeeds'() {
         given:
         buildFile << """
@@ -38,7 +37,7 @@ class Issue47Test extends FunctionalSpecification {
         File sourceFile = new File(testProjectDir.newFolder('src', 'main', 'java'), 'Main.java')
         sourceFile << """
             package com.test.app;
-            
+
             public class Main {
                 public static void main(String[] args) {
                     System.out.println("Hello World!");
@@ -81,7 +80,7 @@ class Issue47Test extends FunctionalSpecification {
             launch4j {
                 outfile = 'test.exe'
                 copyConfigurable = project.tasks.shadowJar.outputs.files
-                jar = "lib/" + project.tasks.shadowJar.archiveName
+                jarTask = project.tasks.shadowJar
             }
         """
 

--- a/src/test/groovy/edu/sc/seis/launch4j/Issue77Test.groovy
+++ b/src/test/groovy/edu/sc/seis/launch4j/Issue77Test.groovy
@@ -32,14 +32,12 @@ class Issue77Test extends FunctionalSpecification {
                 mainClassName = 'com.test.app.Main'
                 outfile = 'notWrapped.exe'
                 dontWrapJar = true
-                jar = "lib/${projectDir.name}.jar"
             }
-            
             
             task usingOverriddenLaunch4j(type: edu.sc.seis.launch4j.tasks.Launch4jLibraryTask) {
                 dontWrapJar = false
                 outfile = 'wrapped.exe'
-                jar = "lib/${projectDir.name}.jar"
+                outputDir = 'launch4jWrapped'
             }
 
         """
@@ -64,7 +62,7 @@ class Issue77Test extends FunctionalSpecification {
         result.task(':createExe').outcome == SUCCESS
 
         when:
-        def outfile = new File(projectDir, 'build/launch4j/wrapped.exe')
+        def outfile = new File(projectDir, 'build/launch4jWrapped/wrapped.exe')
         def jarfile = new File(projectDir, "build/launch4j/lib/${projectDir.name}.jar")
         then:
         outfile.exists()
@@ -87,7 +85,6 @@ class Issue77Test extends FunctionalSpecification {
                 mainClassName = 'com.test.app.Main'
                 outfile = 'notWrapped.exe'
                 dontWrapJar = true
-                jar = "lib/${projectDir.name}.jar"
             }
         """
 

--- a/src/test/groovy/edu/sc/seis/launch4j/Launch4jPluginExtensionTest.groovy
+++ b/src/test/groovy/edu/sc/seis/launch4j/Launch4jPluginExtensionTest.groovy
@@ -79,7 +79,6 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
         def testOutput = new File(projectDir, 'testOutput')
         testOutput.exists()
         new File(projectDir, "testOutput/Test.exe").exists()
-        new File(projectDir, "testOutput/lib/testProject.jar").exists()
 
         testOutput.traverse {
             switch (it.absolutePath){
@@ -122,7 +121,6 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
         result.task(':createExe').outcome == SUCCESS
 
         new File(projectDir, 'build/launch4j/Test.exe').exists()
-        new File(projectDir, 'build/launch4j/lib/testProject.jar').exists()
 
         when:
         def resultTwo = build('cleanCreateExe')
@@ -131,7 +129,6 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
         resultTwo.task(':cleanCreateExe').outcome == SUCCESS
 
         !new File(projectDir, 'build/launch4j/Test.exe').exists()
-        !new File(projectDir, 'build/launch4j/lib/testProject.jar').exists()
         !new File(projectDir, 'build/launch4j').exists()
     }
 
@@ -164,7 +161,6 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
         result.task(':createExe').outcome == SUCCESS
 
         new File(projectDir, 'build/launch4j/Test.exe').exists()
-        new File(projectDir, 'build/launch4j/lib/testProject.jar').exists()
 
         when:
         def resultTwo = build('createExe')
@@ -667,7 +663,7 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
             launch4j {
                 outfile = 'test.exe'
                 copyConfigurable = project.tasks.shadowJar.outputs.files
-                jar = "lib/" + project.tasks.shadowJar.archiveName
+                jarTask = project.tasks.shadowJar
             }
         """
 
@@ -734,7 +730,7 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
             launch4j {
                 outfile = 'test.exe'
                 copyConfigurable = project.tasks.shadowJar.outputs.files
-                jar = "lib/" + project.tasks.shadowJar.archiveName
+                jarTask = project.tasks.shadowJar
             }
         """
 
@@ -776,6 +772,7 @@ class Launch4jPluginExtensionTest extends FunctionalSpecification {
         given:
         buildFile << """
             launch4j {
+                dontWrapJar = true
                 mainClassName = 'com.test.app.Main'
                 outfile = 'Test.exe'
             }


### PR DESCRIPTION
Potentially this is a breaking change (as user-defined value of 'jar' property will be ignored now, if there is a JavaPlugin applied), but I believe this way of plugin configuration is a more Gradle-way, as it encourage tasks composition, and eliminate potentially undesired implicit tasks dependencies and file I/O operations. Also configuration should become more concise and type-safe.

If jar property was not set, then no migration actions are required. Otherwise, the 'jar' property with a path to produced jar should be replaced with new 'jarTask' property with a Task, which produced it as an output.