### PR TITLE
Allow not copy libs (for particular launch4j task)

### DIFF
--- a/src/main/groovy/edu/sc/seis/launch4j/tasks/DefaultLaunch4jTask.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/tasks/DefaultLaunch4jTask.groovy
@@ -138,7 +138,7 @@ abstract class DefaultLaunch4jTask extends DefaultTask implements Launch4jConfig
     }
 
     Object getCopyConfigurable() {
-        copyConfigurable ?: config.copyConfigurable
+        copyConfigurable == null ? config.copyConfigurable : copyConfigurable
     }
 
     FileCollection copyLibraries() {


### PR DESCRIPTION
At this moment plugin allows to configure all launch4j tasks instances in a way when `libraryDir` will not be created and no files will be copied into:

```groovy
launch4j {
    copyConfigurable = []
}
```

This PR additionally allows to configure particular task(s) the same way:

```groovy
createExe {
    copyConfigurable = []
}
```