### PR TITLE
Annotate getLibraryDirectory() method

### DIFF
--- a/src/main/groovy/edu/sc/seis/launch4j/tasks/DefaultLaunch4jTask.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/tasks/DefaultLaunch4jTask.groovy
@@ -105,6 +105,7 @@ abstract class DefaultLaunch4jTask extends DefaultTask implements Launch4jConfig
         libraryDir ?: config.libraryDir
     }
 
+    @Internal
     File getLibraryDirectory() {
         project.file("${getOutputDirectory()}/${libraryDir ?: config.libraryDir}")
     }


### PR DESCRIPTION
This fixes deprecation warning in latest Gradle versions:
```
> Task :createExe
Property 'libraryDirectory' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.6.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```