### PR TITLE
fix jcenter deprecation warning for projects applying this plugin

### DIFF
--- a/src/main/groovy/edu/sc/seis/launch4j/Launch4jPlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Launch4jPlugin.groovy
@@ -85,8 +85,8 @@ class Launch4jPlugin implements Plugin<Project> {
 
 
         if (project.repositories.isEmpty()) {
-            project.logger.debug("Adding the jcenter repository to retrieve the $LAUNCH4J_PLUGIN_NAME files.")
-            project.repositories.jcenter()
+            project.logger.debug("Adding the mavenCentral repository to retrieve the $LAUNCH4J_PLUGIN_NAME files.")
+            project.repositories.mavenCentral()
         }
         def l4jArtifact = "net.sf.launch4j:launch4j:${ARTIFACT_VERSION}"
         project.dependencies {


### PR DESCRIPTION
Applying plugin in projects using Gradle 7.x results in a warning:

```
> Configure project :
The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.0.2/userguide/upgrading_version_6.html#jcenter_deprecation
	at org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.deprecateJCenter(DefaultRepositoryHandler.java:130)
	at org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.jcenter(DefaultRepositoryHandler.java:114)
	at edu.sc.seis.launch4j.Launch4jPlugin.configureDependencies(Launch4jPlugin.groovy:89)
	at edu.sc.seis.launch4j.Launch4jPlugin.apply(Launch4jPlugin.groovy:60)
	at edu.sc.seis.launch4j.Launch4jPlugin.apply(Launch4jPlugin.groovy)
```
	
This PR resolves this warning by changing the repository to retrieve the launch4j from jcenter to mavenCentral.

This partly resolves #107