### PR TITLE
fix macOS version determination

### DIFF
--- a/src/main/groovy/edu/sc/seis/launch4j/Launch4jPlugin.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Launch4jPlugin.groovy
@@ -117,7 +117,7 @@ class Launch4jPlugin implements Plugin<Project> {
     static boolean isBelowMacOsX108() {
         def version = System.getProperty("os.version").split('\\.')
         def major = version[0] as int
-        def minor = version[0] as int
+        def minor = version[1] as int
         return major < 10 || (major == 10 && minor < 8)
     }
 }


### PR DESCRIPTION
Currently, MacOS version is incorrectly determined, which leads to incorrect builds for MacOS 10.0..10.7