### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The values configurable within the launch4j extension along with their defaults 
 | String outfile | project.name+'.exe' | |
 | String errTitle | "" | |
 | String cmdLine | "" | |
-| String chdir | '.' | |
+| String chdir | '.' | After launching, '.' changes working directory to directory of executable, or '' to not change. Note that env variable `%OLDPWD%` contains the original working directory and can be passed on launch to your application if needed. |
 | String priority | 'normal' | |
 | String downloadUrl | "http://java.com/download" | |
 | String supportUrl | "" | |


### PR DESCRIPTION
I was struggling with the creation of a command-line utility, that takes relative paths, since launch4j by default immediately discards the original working directory.

Not sure where to put this, but I think we could at least add a description for `chdir` option with some hints