### PR TITLE
Upgrade to gradle 8 and fix fcp.mode deprecation, making this plugin compatible with gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.gradle.plugin-publish" version "1.3.0"
+    id "com.gradle.plugin-publish" version "1.3.1"
     id 'java-gradle-plugin'
     id 'groovy'
     id 'jacoco'
@@ -7,7 +7,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id "com.jfrog.artifactory" version "4.33.1"
-    id 'org.unbroken-dome.test-sets' version '4.0.0'
+    id 'org.unbroken-dome.test-sets' version '4.1.0'
 }
 
 repositories {
@@ -16,7 +16,7 @@ repositories {
 
 ext {
     ARTIFACT_VERSION = '3.50'
-    spock_version = '1.3-groovy-2.5'
+    spock_version = '2.3-groovy-3.0'
 }
 
 testSets {
@@ -60,15 +60,14 @@ gradlePlugin {
             displayName = 'launch4j gradle plugin'
             description = 'A gradle-plugin to create windows executables with launch4j for Java application.'
             implementationClass = 'edu.sc.seis.launch4j.Launch4jPlugin'
+            tags = ['launch4j', 'executable', 'wrapper']
         }
     }
-}
 
-pluginBundle {
     website = 'https://github.com/TheBoegl/gradle-launch4j'
     vcsUrl = 'https://github.com/TheBoegl/gradle-launch4j'
     description = 'A gradle-plugin to create windows executables with launch4j for Java application.'
-    tags = ['launch4j', 'executable', 'wrapper']
+
 }
 
 publishPlugins.dependsOn build
@@ -109,9 +108,9 @@ tasks.withType(Test).configureEach {
 
 jacocoTestReport {
     reports {
-        xml.enabled false
-        csv.enabled false
-        html.enabled true
+        xml.required = false
+        csv.required = false
+        html.required = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ artifactory {
 //createReleaseTag.dependsOn publish
 
 wrapper {
-    gradleVersion = '6.9.4'
+    gradleVersion = '8.14.3'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/edu/sc/seis/launch4j/Extract.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/Extract.groovy
@@ -43,7 +43,7 @@ class Extract {
                         def segments = fcp.relativePath.segments
                         def pathSegments = segments[1..-1] as String[]
                         fcp.relativePath = new RelativePath(!fcp.file.isDirectory(), pathSegments)
-                        fcp.mode = 0755
+                        fcp.permissions { it.unix(0755) }
                     } else {
                         fcp.exclude()
                     }

--- a/src/main/groovy/edu/sc/seis/launch4j/tasks/DefaultLaunch4jTask.groovy
+++ b/src/main/groovy/edu/sc/seis/launch4j/tasks/DefaultLaunch4jTask.groovy
@@ -243,7 +243,7 @@ abstract class DefaultLaunch4jTask extends DefaultTask implements Launch4jConfig
         copyLibraryFileCollection = configurableFileCollection(project)
     }
 
-    private static File getWorkingJar(ConfigurableFileCollection launch4jBinaryFiles) {
+    public static File getWorkingJar(ConfigurableFileCollection launch4jBinaryFiles) {
         def workingDirName = Launch4jPlugin.workdir()
         def jarName = "launch4j-(\\d{1,2}\\.\\d{1,2})-${workingDirName}"
         def workingJar = launch4jBinaryFiles.files.find { File file -> file.name =~ /${jarName}.jar/ }


### PR DESCRIPTION
I followed the documentation and tested this. See
https://docs.gradle.org/current/javadoc/org/gradle/api/file/FileCopyDetails.html

Also fixes configuration cache incompatibility